### PR TITLE
Revert to the original parameter stringify method

### DIFF
--- a/includes/classes/AmazonCore.php
+++ b/includes/classes/AmazonCore.php
@@ -852,14 +852,11 @@ abstract class AmazonCore{
      * @return string
      */
     protected function _getParametersAsString(array $parameters) {
-//        $queryParameters = array();
-//        foreach ($parameters as $key => $value) {
-//            $queryParameters[] = $key . '=' . $this->_urlencode($value);
-//        }
-//        return implode('&', $queryParameters);
-
-        // We may as well use the input method!
-        return http_build_query($parameters);
+        $queryParameters = array();
+        foreach ($parameters as $key => $value) {
+            $queryParameters[] = $key . '=' . $this->_urlencode($value);
+        }
+        return implode('&', $queryParameters);
     }
     
     /**


### PR DESCRIPTION
The way the params were stringified in the original repo is actually preferable, as using your way the created signatures are invalid when your params have spaces or other non-url safe characters in them. I've verified this on the InboundShipments Api methods where I was pushing SKUs containing spaces and forward slashes. With the method like this it works, and with the modified version you either end up double-encoding or you get an invalid signature error and the call fails